### PR TITLE
Fix "Class 'App\Manipulations' not found" error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,4 +65,3 @@ VITE_APP_NAME="${APP_NAME}"
 
 # Customizations
 SANCTUM_STATEFUL_DOMAINS=yourdomain.test
-SESSION_DOMAIN=yourdomain.test

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Silber\Bouncer\Database\HasRolesAndAbilities;
-use Spatie\Image\Manipulations;
+use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -154,13 +154,13 @@ class User extends Authenticatable implements HasMedia, MustVerifyEmail
     public function registerMediaConversions(?Media $media = null): void
     {
         $this->addMediaConversion('small_thumb')
-            ->fit(Manipulations::FIT_CROP, 300, 300)
+            ->fit(Fit::Fill, 300, 300)
             ->nonQueued();
         $this->addMediaConversion('medium_thumb')
-            ->fit(Manipulations::FIT_CROP, 600, 600)
+            ->fit(Fit::Fill, 600, 600)
             ->nonQueued();
         $this->addMediaConversion('large_thumb')
-            ->fit(Manipulations::FIT_CROP, 1200, 1200)
+            ->fit(Fit::Fill, 1200, 1200)
             ->nonQueued();
     }
 }


### PR DESCRIPTION
The current installation gives a `Class 'App\Manipulations' not found` on image uploads in profile.
This is due Spatie\Image\Manipulations has been deprecated in v3

[v2](https://spatie.be/docs/image/v2/introduction): ->fit(Manipulations::FIT_FILL, 500, 300)

[v3](https://spatie.be/docs/image/v3/introduction): ->fit(Fit::Fill, 500, 300)
